### PR TITLE
create testing tool that allows allows user to call the addContractVo…

### DIFF
--- a/voucher-registry-testing-tool/VouchersRegistry.json
+++ b/voucher-registry-testing-tool/VouchersRegistry.json
@@ -1,0 +1,353 @@
+[
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "safetyCheckPassedContracts",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "safetyCheckFailedContracts",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "contractVouchersDonorBalance",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "isOwner",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "contractVouchersRedeemablePerUser",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "addressIdentityVerified",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "contractVouchersAddressRedeemed",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "refundee",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "refundAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "AddressNotPassedSafetyCheckRefund",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "contractAddress",
+          "type": "address"
+        },
+        {
+          "name": "status",
+          "type": "string"
+        },
+        {
+          "name": "checkVersion",
+          "type": "uint256"
+        }
+      ],
+      "name": "setContractStatus",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "userAddress",
+          "type": "address"
+        },
+        {
+          "name": "verificationToken",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAddressIdentityVerified",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "contractAddress",
+          "type": "address"
+        },
+        {
+          "name": "redeemablePerUser",
+          "type": "uint256"
+        }
+      ],
+      "name": "addContractVouchers",
+      "outputs": [],
+      "payable": true,
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "contractAddress",
+          "type": "address"
+        },
+        {
+          "name": "withdrawAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "withdrawContractVouchers",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "contractAddress",
+          "type": "address"
+        },
+        {
+          "name": "donorAddress",
+          "type": "address"
+        },
+        {
+          "name": "redeemAmount",
+          "type": "uint256"
+        },
+        {
+          "name": "callData",
+          "type": "bytes"
+        }
+      ],
+      "name": "redeemContractVouchers",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "donorAddress",
+          "type": "address"
+        },
+        {
+          "name": "contractAddress",
+          "type": "address"
+        }
+      ],
+      "name": "getVoucherKey",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "donorAddress",
+          "type": "address"
+        },
+        {
+          "name": "contractAddress",
+          "type": "address"
+        },
+        {
+          "name": "userAddress",
+          "type": "address"
+        }
+      ],
+      "name": "getUserKey",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "pure",
+      "type": "function"
+    }
+  ]

--- a/voucher-registry-testing-tool/index.html
+++ b/voucher-registry-testing-tool/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Voucher Registry Testing Tool</title>
+  <script src="https://cdn.rawgit.com/ethereum/web3.js/develop/dist/web3.js"></script>
+  <script src="https://cdn.rawgit.com/ethereumjs/browser-builds/master/dist/ethereumjs-tx/ethereumjs-tx-1.3.3.js"></script>
+  <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js"></script>
+  <script type="text/javascript" src="./VouchersRegistry.json"></script>
+  <script src="./index.js"></script>
+</head>
+<body class="container">
+
+    <h1>Add contract to VouchersRegistry</h1>
+
+    <h4>Safety check passed contracts:</h4>
+
+    <h5>0xa1427b62e0c116a4feba4e9fec8269930cb5b5f0 - function buyToken() public payable</h5>
+    <h5>0x46D69Aba7F54cA94375E14e91B1401f5e1717af4 - function buy(address payable _referrer) public payable</h5>
+    <h5>0x4520aaeDCe6755aB1CAd316FF17147797e92b2C6 - function BuyTokens(address beneficiary) public payable</h5>
+
+
+	<form action="javascript:void(0);" onsubmit="onSendTransaction(this)">
+  		Contract Address: <input type="text" name="contract"><br>
+  		Value (in wei): <input type="text" name="value"><br>
+  		Redeemable per user: <input type="text" name="redeemablePerUser"><br>
+  		<input type="submit" value="Send Transaction">
+	</form>
+
+
+</body>
+</html>

--- a/voucher-registry-testing-tool/index.js
+++ b/voucher-registry-testing-tool/index.js
@@ -1,0 +1,87 @@
+
+const infura_apikey = "155f5547dd0e4ab09bded202e8bcc08a";
+const web3 = new Web3(new Web3.providers.HttpProvider("https://ropsten.infura.io/v3/"+ infura_apikey))
+
+const wallet_address = "0x0eEB66338d9672Ba67a4342ECE388E4026f9b43d";
+const wallet_private_key = "943eed2a06c4ba5991cf724ead779bebca00a7e47d3f29a2a334c7447a763b95";
+const wallet_private_key_buffer = new ethereumjs.Buffer.Buffer(wallet_private_key, "hex")
+
+const voucher_registry_contract_address = "0x93063EF391E6a33879cF3cA9a4B92cCf1EFDe82d";
+const voucher_user_contract_address = "0xe957DacBbC9d78502CFde65d5E24131b173869Cc";
+
+let VouchersRegistry = null;
+let vouchersRegistryContract = null;
+
+//Load the contract ABI from JSON file, and then create a contract variable pointing to the one on the Ropsten testnet
+function loadVouchersRegistry() {
+    var xobj = new XMLHttpRequest();
+
+    xobj.overrideMimeType("application/json");
+    xobj.open('GET', 'VouchersRegistry.json', false);
+
+    xobj.onreadystatechange = function () {
+        if (xobj.readyState == 4 && xobj.status == "200") {
+            VouchersRegistry = web3.eth.contract(JSON.parse(xobj.responseText));
+            vouchersRegistryContract = VouchersRegistry.at(voucher_registry_contract_address);
+        }
+    };
+    xobj.send(null);  
+}
+
+loadVouchersRegistry();
+
+//Called when Send Transaction button is clicked.
+function onSendTransaction(form){
+    if(!vouchersRegistryContract) {
+        console.log("Error loading contract ABI.");
+        return;
+    }
+   
+    const contract = form.elements["contract"].value;
+    const value = form.elements["value"].value;
+    const redeemablePerUser = form.elements["redeemablePerUser"].value;
+
+    console.log(vouchersRegistryContract)
+
+    try {
+        //Get number of transactions sent from the wallet_address to use as the nonce
+        web3.eth.getTransactionCount(wallet_address, function(err, txCount) {
+            if(err) {
+                console.log("Error getting transaction count: " + err);
+                return;
+            }
+            
+            const data = vouchersRegistryContract.addContractVouchers.getData(contract, redeemablePerUser);
+
+            const rawTx = {
+                nonce: web3.toHex(txCount),
+                from: wallet_address,
+                to: voucher_registry_contract_address,
+                value: web3.toHex(value),
+                data: data,
+                gas: 200000,
+                gasPrice: 50e9,
+                chainId: 3
+            };
+
+            const signedTx = new ethereumjs.Tx(rawTx);
+
+            signedTx.sign(wallet_private_key_buffer);
+
+            const serializedTx = signedTx.serialize();
+
+            web3.eth.sendRawTransaction("0x" + serializedTx.toString("hex"), function(err, hash)
+            {
+                if(err) {
+                    console.log("Error sending transaction: " + err);
+                } else {
+                    console.log("Transaction hash: " + hash);
+                }
+            });
+
+        })
+    }
+    catch(err) {
+        console.log(err)
+    }
+}


### PR DESCRIPTION
…uchers function with parameters for contract, value, and redeemable per user, on already-deployed VouchersRegistry contract on the Ropsten testnet.

It calculates number of transactions to generate the nonce, and signs the transaction with the private key of the owner of the VouchersRegistry contract.
Upon successfully sending the transaction to the network, the transaction's hash is logged in the console.